### PR TITLE
Add options --src-file and --dst-file to encrypt and decrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Add `reversible_cryptography` command
 $ reversible_cryptography
 
 Commands:
-  reversible_cryptography decrypt [TEXT]  # Decrypt text
-  reversible_cryptography encrypt [TEXT]  # Encrypt text
+  reversible_cryptography decrypt [TEXT]  # Decrypt text or file
+  reversible_cryptography encrypt [TEXT]  # Encrypt text or file
   reversible_cryptography help [COMMAND]  # Describe available commands or one specific command
 ```
 
@@ -47,12 +47,32 @@ Input password:
 md5:78e731027d8fd50ed642340b7c9a63b3:salt:252-235-72-88-180-7-195-229:aes-256-cfb:VH2JxqUU9Q==
 ```
 
+```shell
+cat original.txt
+this is secret!
+
+reversible_cryptography encrypt --password=pass --src-file=original.txt --dst-file=encrypted.txt
+
+cat encrypted.txt
+md5:f5b013aca1b774be3d3b5f09f76e6cc8:salt:228-129-190-248-134-146-102-97:aes-256-cfb:u+lhtAdW6Re8br0qePqzig==
+```
+
 #### Decrypt sample
 
 ```shell
 reversible_cryptography decrypt md5:78e731027d8fd50ed642340b7c9a63b3:salt:252-235-72-88-180-7-195-229:aes-256-cfb:VH2JxqUU9Q==
 Input password:
 message
+```
+
+```shell
+cat encrypted.txt
+md5:f5b013aca1b774be3d3b5f09f76e6cc8:salt:228-129-190-248-134-146-102-97:aes-256-cfb:u+lhtAdW6Re8br0qePqzig==
+
+reversible_cryptography decrypt --password=pass --src-file=encrypted.txt --dst-file=decrypted.txt
+
+cat decrypted.txt
+this is secret!
 ```
 
 ## Development

--- a/lib/reversible_cryptography/cli.rb
+++ b/lib/reversible_cryptography/cli.rb
@@ -3,24 +3,44 @@ require 'reversible_cryptography'
 
 module ReversibleCryptography
   class CLI < Thor
-    desc "encrypt [TEXT]", "Encrypt text"
+    desc "encrypt [TEXT]", "Encrypt text or file"
     option :password, type: :string, aliases: [:p]
+    option :src_file, type: :string, aliases: [:s], banner: "PLAIN_TEXT_FILE"
+    option :dst_file, type: :string, aliases: [:d], banner: "ENCRYPTED_TEXT_FILE"
     def encrypt(plain_text=nil)
+      plain_text = File.read(options[:src_file]) if options[:src_file]
       plain_text ||= ask("Input text:")
       password = options[:password]
       password ||= ask("Input password:", echo: false).tap { puts }
 
-      puts ReversibleCryptography::Message.encrypt(plain_text, password)
+      encrypted_text = ReversibleCryptography::Message.encrypt(plain_text, password)
+      if options[:dst_file]
+        File.open(options[:dst_file], "wb") do |f|
+          f.write(encrypted_text)
+        end
+      else
+        puts encrypted_text
+      end
     end
 
-    desc "decrypt [TEXT]", "Decrypt text"
+    desc "decrypt [TEXT]", "Decrypt text or file"
     option :password, type: :string, aliases: [:p]
+    option :src_file, type: :string, aliases: [:s], banner: "ENCRYPTED_TEXT_FILE"
+    option :dst_file, type: :string, aliases: [:d], banner: "PLAIN_TEXT_FILE"
     def decrypt(encrypted_text=nil)
+      encrypted_text = File.read(options[:src_file]) if options[:src_file]
       encrypted_text ||= ask("Input text:")
       password = options[:password]
       password ||= ask("Input password:", echo: false).tap { puts }
 
-      puts ReversibleCryptography::Message.decrypt(encrypted_text, password)
+      plain_text = ReversibleCryptography::Message.decrypt(encrypted_text, password)
+      if options[:dst_file]
+        File.open(options[:dst_file], "wb") do |f|
+          f.write(plain_text)
+        end
+      else
+        puts plain_text
+      end
     end
   end
 end


### PR DESCRIPTION
# Overview

Support file options (`--src-file`, `dst-file`) to cli
# Examples
## Encrypt

``` sh
$ bundle exec exe/reversible_cryptography help encrypt
Usage:
  reversible_cryptography encrypt [TEXT]

Options:
  p, [--password=PASSWORD]
  s, [--src-file=PLAIN_TEXT_FILE]   # <--- ADD THIS
  d, [--dst-file=ENCRYPTED_TEXT_FILE]   # <--- ADD THIS

Encrypt text

$ cat tmp/original.txt
this is secret!

$ bundle exec ./exe/reversible_cryptography encrypt --password=pass --src-file=tmp/original.txt --dst-file=tmp/encrypted.txt

$ cat tmp/encrypted.txt
md5:f5b013aca1b774be3d3b5f09f76e6cc8:salt:228-129-190-248-134-146-102-97:aes-256-cfb:u+lhtAdW6Re8br0qePqzig==
```
## Decrypt

``` sh
$ bundle exec exe/reversible_cryptography help decrypt
Usage:
  reversible_cryptography decrypt [TEXT]

Options:
  p, [--password=PASSWORD]
  s, [--src-file=ENCRYPTED_TEXT_FILE]   # <--- ADD THIS
  d, [--dst-file=PLAIN_TEXT_FILE]  # <--- ADD THIS

$ cat tmp/encrypted.txt
md5:f5b013aca1b774be3d3b5f09f76e6cc8:salt:228-129-190-248-134-146-102-97:aes-256-cfb:u+lhtAdW6Re8br0qePqzig==

$ bundle exec ./exe/reversible_cryptography decrypt --password=pass --src-file=tmp/encrypted.txt --dst-file=tmp/decrypted.txt

$ cat tmp/decrypted.txt
this is secret!
```
